### PR TITLE
Dev add today button

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 
 addons:
     chrome: stable

--- a/Controllers/Commands/retrieve_timetable.py
+++ b/Controllers/Commands/retrieve_timetable.py
@@ -198,7 +198,13 @@ def get_keyboard(tg_id: str, current_date, start_date, end_date):
         nested_keyboard.append(
             InlineKeyboardButton("Next Week ➡", callback_data=next_date_trigger)
         )
+
+    today_date_trigger = f"td{datetime.strftime(current_date,'%b%d%Y')}"
+    today_date_keyboard = [
+        InlineKeyboardButton("This Week ⬆ ️", callback_data=today_date_trigger)
+    ]
     keyboard.append(nested_keyboard)
+    keyboard.append(today_date_keyboard)
     return keyboard
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -307,7 +307,7 @@ description = "Python bindings for Selenium"
 name = "selenium"
 optional = false
 python-versions = "*"
-version = "3.10.0"
+version = "3.8.0"
 
 [[package]]
 category = "main"

--- a/poetry.lock
+++ b/poetry.lock
@@ -183,7 +183,7 @@ description = "Messaging library for Python."
 name = "kombu"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "4.2.2"
+version = "4.2.2.post1"
 
 [package.dependencies]
 amqp = ">=2.1.4,<3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ keywords = ['telegram bot', 'SIMConnect', 'web scraping']
 python = "^3.6" 
 toml = "^0.9"
 # Dependencies with extras
-selenium = { version = "3.10.0" }
+selenium = { version = "3.8.0" }
 pip = { version = "~9.0.1" }
 redis = { version = "~2.10.6" }
 jsonpickle = { version = "~0.9.6" }


### PR DESCRIPTION
* Fixed issues in `poetry.lock` whereby celery had a dependency issue w/ poetry, as `kombu` 3.2.2 was tagged as 3.2.2.post1, thus poetry was unabled to detect it
* Fixed a regression issue with selenium  > 3.8.0 and rolled it back to a lower version to avoid a socket error.
* Added QOL for users, introducing a new "today" button.